### PR TITLE
correction erreur affichage result

### DIFF
--- a/src/Controller/GameController.php
+++ b/src/Controller/GameController.php
@@ -234,6 +234,12 @@ class GameController extends AbstractController
 
     public function result(): string
     {
+        if (!isset($_SESSION['game'])) {
+            echo 'Unauthorized access';
+            header('HTTP/1.1 403 Forbidden');
+            exit();
+        }
+
         $resultmanager = new ResultManager();
         $game =  $_SESSION['game'];
         if (!(count($game->getScore()) === $this->maxQuestion)) {


### PR DESCRIPTION
On pouvait accéder à la page result en la rentrant dans la barre d'adresse alors qu'on n'avait pas commencé une parti, j'ai donc mis un garde fou pour éviter cela